### PR TITLE
Jacob/etcd

### DIFF
--- a/etcd/versions/1.0.0/README.md
+++ b/etcd/versions/1.0.0/README.md
@@ -1,16 +1,16 @@
-## etcd App
+## etcd
 
 etcd is a distributed, reliable key-value store for the most critical data of a distributed system. It provides a reliable way to store data that needs to be accessed by a distributed system or cluster of machines. etcd is essential for maintaining cluster health by providing consistent coordination, service discovery, and configuration management across distributed systems.
 
-### Key Features
+### Configuring etcd
 
-- **Distributed**: etcd is designed to be distributed across multiple nodes for high availability
-- **Consistent**: Provides strong consistency guarantees for all operations
-- **Reliable**: Built-in leader election and automatic failover capabilities
+Update the `values.yaml` file with your settings:
 
-### Accessing etcd
-
-Workloads are allowed to access etcd based on the `internal-access` you specify in `values.yaml`. You can learn more about it in our [documentation](https://docs.controlplane.com/reference/workload#internal).
+- **`replicas`**: Number of etcd instances (default: 3, must be odd)
+- **`resources.cpu`**: CPU per instance (default: 1 vCPU)
+- **`resources.memory`**: Memory per instance (default: 2 GB RAM)
+- **`internal_access.type`**: Internal firewall access (`same-gvc`, `same-org`, or `workload-list`)
+- **`internal_access.workloads`**: Specific workloads (when using `workload-list` or `same-gvc`)
 
 ### Supported External Services
-- [etcd Docs](https://etcd.io/docs/v3.6/)
+- [etcd docs](https://etcd.io/docs/v3.6/)

--- a/etcd/versions/1.0.0/templates/identity.yaml
+++ b/etcd/versions/1.0.0/templates/identity.yaml
@@ -1,0 +1,6 @@
+---
+kind: identity
+gvc: {{ .Values.global.cpln.gvc }}
+name: etcd-identity
+description: etcd-identity
+tags: {}

--- a/etcd/versions/1.0.0/templates/policy.yaml
+++ b/etcd/versions/1.0.0/templates/policy.yaml
@@ -1,0 +1,13 @@
+---
+kind: policy
+name: etcd-{{ .Values.global.cpln.gvc }}-policy
+description: etcd-{{ .Values.global.cpln.gvc }}-policy
+tags: {}
+bindings:
+  - permissions:
+      - reveal
+    principalLinks:
+      - //gvc/{{ .Values.global.cpln.gvc }}/identity/etcd-identity
+targetKind: secret
+targetLinks:
+  - //secret/etcd-startup

--- a/etcd/versions/1.0.0/templates/secret.yaml
+++ b/etcd/versions/1.0.0/templates/secret.yaml
@@ -1,0 +1,55 @@
+---
+kind: secret
+name: etcd-startup
+description: etcd startup script
+type: opaque
+data:
+  encoding: plain
+  payload: |-
+    #!/bin/bash
+    set -euo pipefail
+
+    # Runtime env provided by Control Plane
+    LOCATION=$(basename "${CPLN_LOCATION}")
+    HOSTNAME=${HOSTNAME}
+
+    # Extract replica index from HOSTNAME
+    REPLICA_INDEX=$(echo "${HOSTNAME}" | awk -F'-' '{print $NF}')
+    WORKLOAD_NAME=$(echo "${HOSTNAME}" | sed 's/-[0-9]*$//')
+
+    # Self FQDN for peer URLs
+    SELF_FQDN="replica-${REPLICA_INDEX}.${WORKLOAD_NAME}.${LOCATION}.{{ .Values.global.cpln.gvc }}.cpln.local"
+
+    # Build initial cluster list based on replicas
+    INITIAL_CLUSTER=""
+    for i in $(seq 0 $(({{ .Values.replicas }} - 1))); do
+      peer="replica-${i}.${WORKLOAD_NAME}.${LOCATION}.{{ .Values.global.cpln.gvc }}.cpln.local"
+      entry="${WORKLOAD_NAME}-${i}=http://${peer}:2380"
+      if [[ -z "$INITIAL_CLUSTER" ]]; then
+        INITIAL_CLUSTER="$entry"
+      else
+        INITIAL_CLUSTER="${INITIAL_CLUSTER},$entry"
+      fi
+    done
+
+    # Determine cluster state
+    if [ -d "/var/lib/etcd/member" ] && [ "$(ls -A /var/lib/etcd/member)" ]; then
+        INITIAL_CLUSTER_STATE="existing"
+    else
+        INITIAL_CLUSTER_STATE="new"
+    fi
+
+    echo "Starting etcd with cluster state: $INITIAL_CLUSTER_STATE"
+
+    # Run etcd
+    exec etcd \
+      --name "${WORKLOAD_NAME}-${REPLICA_INDEX}" \
+      --data-dir /var/lib/etcd \
+      --listen-client-urls "http://0.0.0.0:2379" \
+      --advertise-client-urls "http://${SELF_FQDN}:2379" \
+      --listen-peer-urls "http://0.0.0.0:2380" \
+      --initial-advertise-peer-urls "http://${SELF_FQDN}:2380" \
+      --initial-cluster "$INITIAL_CLUSTER" \
+      --initial-cluster-state "$INITIAL_CLUSTER_STATE" \
+      --heartbeat-interval 1000 \
+      --election-timeout 10000

--- a/etcd/versions/1.0.0/templates/workload.yaml
+++ b/etcd/versions/1.0.0/templates/workload.yaml
@@ -6,14 +6,11 @@ spec:
   type: stateful
   containers:
     - name: etcd
+      command: "/bin/bash"
       args:
-        - '--name=etcd-0'
-        - '--data-dir=/var/lib/etcd'
-        - '--listen-client-urls=http://0.0.0.0:2379'
-        - '--advertise-client-urls=http://{{ .Release.Name }}.{{ .Values.global.cpln.gvc }}.cpln.local:2379'
-      command: etcd
-      cpu: {{ .Values.resources.cpu }}
-      image: quay.io/coreos/etcd:v3.6.5
+        - "/etcd/start.sh"
+      cpu: "{{ .Values.resources.cpu }}"
+      image: controlplanecorporation/etcd:0.1
       inheritEnv: false
       memory: {{ .Values.resources.memory }}
       ports:
@@ -25,13 +22,16 @@ spec:
         - path: /var/lib/etcd
           recoveryPolicy: retain
           uri: cpln://volumeset/{{ .Release.Name }}-etcd-vs
+        - path: /etcd/start.sh
+          uri: cpln://secret/etcd-startup.payload
+  identityLink: //gvc/{{ .Values.global.cpln.gvc }}/identity/etcd-identity
   defaultOptions:
     autoscaling:
       keda: {}
       maxConcurrency: 0
-      maxScale: 1
+      maxScale: {{ .Values.replicas }}
       metric: cpu
-      minScale: 1
+      minScale: {{ .Values.replicas }}
       scaleToZeroDelay: 300
       target: 100
     capacityAI: false
@@ -55,5 +55,5 @@ spec:
     direct:
       enabled: false
       ports: []
-    replicaDirect: false
+    replicaDirect: true
   supportDynamicTags: false

--- a/etcd/versions/1.0.0/values.yaml
+++ b/etcd/versions/1.0.0/values.yaml
@@ -1,6 +1,8 @@
+replicas: 3
+
 resources:
-  cpu: 200m
-  memory: 256Mi
+  cpu: 1
+  memory: 2Gi
 
 internal_access:
   type: same-gvc # options: same-gvc, same-org, workload-list


### PR DESCRIPTION
Updated etcd to handle multi-replica. Changed image to use custom controlplanecorporation image which installs bash in order to use startup script and connect to container. Handles restarts, data persistency, and cluster health.