### PR TITLE
redis 3.4.0: configurable probe settings and lifecycle cleanup hooks

### DIFF
--- a/redis/RELEASES.md
+++ b/redis/RELEASES.md
@@ -1,3 +1,11 @@
+# Release Notes - Version 3.4.0
+
+## What's New
+
+- **Configurable Probe Settings**: Readiness and liveness probe timing (`initialDelaySeconds`, `periodSeconds`, `failureThreshold`, `timeoutSeconds`) are now overridable via `redis.probes.readiness` and `redis.probes.liveness` in the values file. The startup probe is derived by the platform from the readiness probe with a fixed `failureThreshold` of 30, giving a startup window of `initialDelaySeconds + (30 × periodSeconds)`. For large persistent datasets increase `periodSeconds` to extend this window.
+- **Temp File Cleanup Hooks**: When `redis.persistence.enabled` is `true`, `postStart` and `preStop` lifecycle hooks are automatically added to remove orphaned `temp-*.rdb` and `temp-rewriteaof-*.aof` files. These files accumulate when pods are terminated mid-sync and can fill the volume over time, causing crash loops.
+
+
 # Release Notes - Version 3.3.0
 
 ## What's New

--- a/redis/versions/3.4.0/Chart.yaml
+++ b/redis/versions/3.4.0/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: redis
+description: A master-replica Redis configuration with Redis Sentinel
+type: application
+version: 3.4.0
+appVersion: "7.4"
+
+annotations:
+  created: "2026-05-25"
+  lastModified: "2026-05-25"
+  category: "cache"
+  createsGvc: false

--- a/redis/versions/3.4.0/Chart.yaml
+++ b/redis/versions/3.4.0/Chart.yaml
@@ -7,6 +7,11 @@ appVersion: "7.4"
 
 annotations:
   created: "2026-05-25"
-  lastModified: "2026-05-25"
+  lastModified: "2026-05-26"
   category: "cache"
   createsGvc: false
+
+dependencies:
+  - name: cpln-common
+    version: 1.0.0
+    repository: "oci://ghcr.io/controlplane-com/templates"

--- a/redis/versions/3.4.0/README.md
+++ b/redis/versions/3.4.0/README.md
@@ -1,0 +1,224 @@
+## Redis Sentinel
+
+Creates a Redis Sentinel cluster on Control Plane with automatic leader election, failover, and an optional backup configuration.
+
+### Configuration
+
+**Redis and Sentinel** — set replicas, resources, and timeouts for each. Sentinel replicas must be an odd number for quorum:
+```yaml
+redis:
+  replicas: 2
+  resources:
+    minCpu: 80m
+    minMemory: 128Mi
+    cpu: 200m
+    memory: 256Mi
+
+sentinel:
+  replicas: 3
+  quorumAutoCalculation: true  # calculates as (replicas/2)+1
+```
+
+**Authentication** — enable one method. Apply the same config under both `redis.auth` and `sentinel.auth`:
+```yaml
+redis:
+  auth:
+    password:
+      enabled: true
+      value: your-password
+    # fromSecret:
+    #   enabled: true
+    #   name: my-redis-secret
+    #   passwordKey: password
+```
+
+**Persistence** — disabled by default. Enable to attach a persistent volume to Redis:
+```yaml
+redis:
+  persistence:
+    enabled: true
+    volumes:
+      data:
+        initialCapacity: 10
+        performanceClass: general-purpose-ssd  # or high-throughput-ssd (min 1000 GiB)
+        fileSystemType: ext4
+```
+
+When persistence is enabled, lifecycle hooks are automatically added to clean up orphaned temp RDB and AOF rewrite files on every container start and stop. These files are left behind when a pod is terminated mid-sync and can fill the volume over time if not removed.
+
+**Probe tuning for large datasets** — the startup probe window is derived from the readiness probe:
+```
+startup window = initialDelaySeconds + (30 × periodSeconds)
+```
+The default (`10 + 30×5 = 160s`) is sufficient for small datasets. With persistence enabled and a large dataset, replicas must load their local AOF before syncing — which can take 60–120s or more — leaving little time for the actual RDB transfer. Increase `periodSeconds` to extend the window:
+```yaml
+redis:
+  probes:
+    readiness:
+      initialDelaySeconds: 35  # clears the AOF load window
+      periodSeconds: 20         # startup window = 35 + (30×20) = 635s (~10 min)
+```
+
+**Firewall** — set the internal access scope for both Redis and Sentinel:
+```yaml
+firewall:
+  internal_inboundAllowType: same-gvc  # same-gvc, same-org, or workload-list
+```
+
+### Public Access (External TCP)
+
+Redis and Sentinel can be exposed over the internet via TCP using Control Plane's domain resource with per-replica port routing.
+
+#### Prerequisites
+
+1. **A domain you control** with DNS managed by your registrar (e.g. Cloudflare)
+2. **Dedicated Load Balancer** enabled on your GVC — required for arbitrary TCP port routing. Enable this under your GVC settings in the Control Plane console.
+3. **DNS records added before deploying** — Control Plane will reject the domain resource on first deploy if ownership has not been proven. Add the following records in your DNS provider for each address before running the deployment. **Disable proxying** (e.g. Cloudflare's orange cloud) — TCP traffic must pass through directly:
+
+| Type | Name | Value |
+|------|------|-------|
+| TXT | `_cpln-<subdomain>` | your Control Plane org name or org ID (either is accepted) |
+| CNAME | `<subdomain>` | `<gvc-alias>.cpln.app` |
+
+Your GVC alias is visible in the Control Plane console under GVC settings. The TXT record proves domain ownership — without it, the first deploy will fail with an `Unable to apply domain` error.
+
+#### Configuration
+
+Enable `publicAccess` for Redis and/or Sentinel and set a subdomain you own:
+
+```yaml
+redis:
+  publicAccess:
+    enabled: true
+    address: redis.your-domain.com
+  firewall:
+    internal_inboundAllowType: same-gvc
+    external_inboundAllowCIDR: "0.0.0.0/0"  # or restrict to specific CIDRs
+
+sentinel:
+  publicAccess:
+    enabled: true
+    address: redis-sentinel.your-domain.com
+  firewall:
+    internal_inboundAllowType: same-gvc
+    external_inboundAllowCIDR: "0.0.0.0/0"
+```
+
+When enabled, a Control Plane `domain` resource is created for each address. Port mapping is one port per replica:
+- **Redis**: ports `6380`, `6381`, ... (replica 0, 1, ...)
+- **Sentinel**: ports `26380`, `26381`, `26382`, ... (replica 0, 1, 2, ...)
+
+After DNS propagates, the domain status in Control Plane will show **Ready**. You can verify the full DNS chain resolves correctly with:
+
+```bash
+dig <subdomain>.your-domain.com CNAME   # should return <gvc-alias>.cpln.app
+dig <gvc-alias>.cpln.app               # should return an IP address
+```
+
+#### Connecting Externally (Public Access Enabled)
+
+```bash
+# add -a <password> if auth is enabled
+
+# Redis replica 0
+redis-cli -h redis.your-domain.com -p 6380 ping
+
+# Redis replica 1
+redis-cli -h redis.your-domain.com -p 6381 ping
+
+# Sentinel replica 0
+redis-cli -h redis-sentinel.your-domain.com -p 26380 ping
+```
+
+### Connecting
+
+Redis is accessible internally on port 6379:
+```
+RELEASE_NAME-redis.GVC_NAME.cpln.local:6379
+```
+
+Sentinel is accessible on port 26379:
+```
+RELEASE_NAME-sentinel.GVC_NAME.cpln.local:26379
+```
+
+To route writes to the current master:
+```bash
+MASTER_INFO=$(redis-cli -h RELEASE_NAME-sentinel.GVC_NAME.cpln.local -p 26379 SENTINEL get-master-addr-by-name mymaster)
+MASTER_HOST=$(echo $MASTER_INFO | cut -d' ' -f1)
+MASTER_PORT=$(echo $MASTER_INFO | cut -d' ' -f2)
+redis-cli -h $MASTER_HOST -p $MASTER_PORT SET my-key "value"
+```
+
+### Backing Up
+
+Set `backup.enabled` to `true`, configure your provider, and set your desired schedule. The backup image is compatible with all Redis versions.
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 2 * * *"  # daily at 2am UTC
+  provider: aws           # Options: aws or gcp
+```
+
+#### AWS S3
+
+For the backup cron job to access an S3 bucket, complete the following in your AWS account first:
+
+1. Create your bucket. Set `backup.aws.bucket` to its name and `backup.aws.region` to its region.
+
+2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account). Set `backup.aws.cloudAccountName` to its name.
+
+3. Create a new IAM policy with the following JSON (replace `YOUR_BUCKET_NAME`) and set `backup.aws.policyName` to match:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:GetObjectVersion",
+                "s3:DeleteObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::YOUR_BUCKET_NAME",
+                "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+            ]
+        }
+    ]
+}
+```
+
+#### GCS
+
+For the backup cron job to access a GCS bucket, complete the following in your GCP account first:
+
+1. Create your bucket. Set `backup.gcp.bucket` to its name.
+
+2. If you do not have a Cloud Account set up, refer to the docs to [Create a Cloud Account](https://docs.controlplane.com/guides/create-cloud-account). Set `backup.gcp.cloudAccountName` to its name.
+
+**Important**: You must add the `Storage Admin` role when creating your GCP service account.
+
+### Restoring a Backup
+
+Run the following command from a client with access to the bucket (replace `aws s3 cp` with `gsutil cp` for GCS):
+
+```sh
+aws s3 cp s3://BUCKET_NAME/PREFIX/BACKUP_FILE.rdb /tmp/dump.rdb
+redis-cli \
+  -h RELEASE_NAME-redis.GVC_NAME.cpln.local \
+  -p 6379 \
+  --rdb /tmp/dump.rdb
+```
+
+### Supported External Services
+- [Redis Documentation](https://redis.io/docs/)
+- [Redis Sentinel Documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/)
+
+### Release Notes
+See [RELEASES.md](https://github.com/controlplane-com/templates/blob/main/redis/RELEASES.md)

--- a/redis/versions/3.4.0/README.md
+++ b/redis/versions/3.4.0/README.md
@@ -59,6 +59,21 @@ redis:
       periodSeconds: 20         # startup window = 35 + (30×20) = 635s (~10 min)
 ```
 
+**Metrics exporter** — disabled by default. When enabled, a `redis_exporter` sidecar is added to each Redis pod. Control Plane scrapes `:9121/metrics` automatically every 30 seconds and makes the metrics available in the console:
+```yaml
+redis:
+  exporter:
+    enabled: true
+```
+Use `dropMetrics` to filter high-cardinality series before they are stored (regex patterns matched against metric names):
+```yaml
+redis:
+  exporter:
+    dropMetrics:
+      - "redis_commands_latencies_usec_bucket"
+      - "redis_latency_percentiles_usec"
+```
+
 **Firewall** — set the internal access scope for both Redis and Sentinel:
 ```yaml
 firewall:

--- a/redis/versions/3.4.0/templates/_helpers.tpl
+++ b/redis/versions/3.4.0/templates/_helpers.tpl
@@ -1,0 +1,267 @@
+{{/* Resource Naming */}}
+
+{{/*
+Redis Workload Name
+*/}}
+{{- define "redis.name" -}}
+{{- printf "%s-redis" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Sentinel Workload Name
+*/}}
+{{- define "redis.sentinel.name" -}}
+{{- printf "%s-sentinel" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Secret Config Name
+*/}}
+{{- define "redis.secretConfig.name" -}}
+{{- printf "%s-redis-config" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Secret Auth Password Name
+*/}}
+{{- define "redis.secretPassword.name" -}}
+{{- printf "%s-redis-auth-password" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Sentinel Secret Config Name
+*/}}
+{{- define "redis.sentinelSecretConfig.name" -}}
+{{- printf "%s-sentinel-config" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Sentinel Secret Auth Password Name
+*/}}
+{{- define "redis.sentinelSecretPassword.name" -}}
+{{- printf "%s-sentinel-auth-password" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Identity Name
+*/}}
+{{- define "redis.identity.name" -}}
+{{- printf "%s-redis-identity" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Sentinel Identity Name
+*/}}
+{{- define "redis.sentinelIdentity.name" -}}
+{{- printf "%s-sentinel-identity" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Policy Name
+*/}}
+{{- define "redis.policy.name" -}}
+{{- printf "%s-redis-policy" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Sentinel Policy Name
+*/}}
+{{- define "redis.sentinelPolicy.name" -}}
+{{- printf "%s-sentinel-policy" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Volume Set Name
+*/}}
+{{- define "redis.volume.name" -}}
+{{- printf "%s-redis-vs" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Sentinel Volume Set Name
+*/}}
+{{- define "redis.sentinelVolume.name" -}}
+{{- printf "%s-sentinel-vs" .Release.Name }}
+{{- end }}
+
+
+{{/*
+Redis Backup Workload Name
+*/}}
+{{- define "redis.backup.name" -}}
+{{- printf "%s-redis-backup" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Backup Secret Config Name
+*/}}
+{{- define "redis.secretBackup.name" -}}
+{{- printf "%s-redis-backup-config" .Release.Name }}
+{{- end }}
+
+{{/*
+Redis Backup Policy Name
+*/}}
+{{- define "redis.backupPolicy.name" -}}
+{{- printf "%s-redis-backup-policy" .Release.Name }}
+{{- end }}
+
+
+{{/* Validation */}}
+
+{{/*
+Validate backup configuration - when backup is enabled, backup.provider must be set to 'aws' or 'gcp'
+*/}}
+{{- define "redis.validateBackupConfig" -}}
+{{- if .Values.backup.enabled -}}
+  {{- $provider := .Values.backup.provider -}}
+  {{- if not (or (eq $provider "aws") (eq $provider "gcp")) -}}
+    {{- fail "Invalid backup configuration: backup.provider must be set to 'aws' or 'gcp'." -}}
+  {{- end -}}
+  {{- if eq $provider "aws" -}}
+    {{- if not .Values.backup.aws.bucket -}}
+      {{- fail "All fields are required for AWS backup. Missing: backup.aws.bucket" -}}
+    {{- end -}}
+    {{- if not .Values.backup.aws.region -}}
+      {{- fail "All fields are required for AWS backup. Missing: backup.aws.region" -}}
+    {{- end -}}
+    {{- if not .Values.backup.aws.cloudAccountName -}}
+      {{- fail "All fields are required for AWS backup. Missing: backup.aws.cloudAccountName" -}}
+    {{- end -}}
+    {{- if not .Values.backup.aws.policyName -}}
+      {{- fail "All fields are required for AWS backup. Missing: backup.aws.policyName" -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if eq $provider "gcp" -}}
+    {{- if not .Values.backup.gcp.bucket -}}
+      {{- fail "All fields are required for GCP backup. Missing: backup.gcp.bucket" -}}
+    {{- end -}}
+    {{- if not .Values.backup.gcp.cloudAccountName -}}
+      {{- fail "All fields are required for GCP backup. Missing: backup.gcp.cloudAccountName" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "calculateWorkloadCounts" -}}
+{{- $quorumCount := int .Values.sentinel.quorum }}
+{{- $workloadCount := 0 }}
+{{- if eq $quorumCount 1 }}
+  {{- $workloadCount = 1 }}
+{{- else }}
+  {{- $workloadCount = int (add $quorumCount 1) }}
+{{- end }}
+{{- $locations := default (list) .Values.locations }}
+{{- if and $locations (gt (len $locations) 0) }}
+  {{- $locationCount := (len $locations) }}
+  {{- $baseCount := int (div $workloadCount $locationCount) }}
+  {{- $remainderCount := int (mod $workloadCount $locationCount) }}
+  {{- if not .Values.global }}
+    {{- $ := set .Values "global" (dict) }}
+  {{- end }}
+  {{- $ := set .Values.global "baseCount" $baseCount }}
+  {{- $ := set .Values.global "remainderCount" $remainderCount }}
+  {{- $ := set .Values.global "locationCount" $locationCount }}
+  {{- $ := set .Values.global "workloadCount" $workloadCount }}
+{{- end }}
+{{- end }}
+
+
+{{ include "redis.auth" (dict "auth" .Values.redis.auth) }}
+
+redis:
+  image: redis/redis-stack:7.4.0-v3
+  resources:
+    cpu: 200m
+    memory: 256Mi
+    minCpu: 80m
+    minMemory: 128Mi
+  replicas: 3
+  timeoutSeconds: 15
+  auth:
+    fromSecret:
+      enabled: false
+      name: example-redis-auth-password
+      passwordKey: password
+    password:
+      enabled: true
+      value: fu3h4f9834f8
+
+{{/*
+Validate auth configuration block
+*/}}
+{{- define "validateAuth" -}}
+{{- $auth := .auth -}}
+
+{{- /* Check if auth block exists */ -}}
+{{- if $auth -}}
+  {{- /* Count enabled auth methods */ -}}
+  {{- $enabledCount := 0 -}}
+  
+  {{- /* Check fromSecret */ -}}
+  {{- if and (hasKey $auth "fromSecret") $auth.fromSecret.enabled -}}
+    {{- $enabledCount = add1 $enabledCount -}}
+  {{- end -}}
+  
+  {{- /* Check password */ -}}
+  {{- if and (hasKey $auth "password") $auth.password.enabled -}}
+    {{- $enabledCount = add1 $enabledCount -}}
+  {{- end -}}
+  
+  {{- /* Validate that at most one method is enabled */ -}}
+  {{- if gt $enabledCount 1 -}}
+    {{- fail "Only one authentication method can be enabled at a time" -}}
+  {{- end -}}
+  
+  {{- /* If fromSecret is enabled, validate its configuration */ -}}
+  {{- if and (hasKey $auth "fromSecret") $auth.fromSecret.enabled -}}
+    {{- if not (hasKey $auth.fromSecret "name") -}}
+      {{- fail "fromSecret authentication requires a name" -}}
+    {{- end -}}
+    {{- if not (hasKey $auth.fromSecret "passwordKey") -}}
+      {{- fail "fromSecret authentication requires a passwordKey" -}}
+    {{- end -}}
+  {{- end -}}
+  
+  {{- /* If password is enabled, validate its configuration */ -}}
+  {{- if and (hasKey $auth "password") $auth.password.enabled -}}
+    {{- if not (hasKey $auth.password "value") -}}
+      {{- fail "password authentication requires a value" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/* Labeling */}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis.tags" -}}
+helm.sh/chart: {{ include "redis.chart" . }}
+{{ include "redis.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.cpln.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.cpln.io/managed-by: {{ .Release.Service }}
+cpln/marketplace: "true"
+cpln/marketplace-template: redis
+cpln/marketplace-template-version: {{ .Chart.Version }}
+cpln/marketplace-gvc: {{ .Values.global.cpln.gvc }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redis.selectorLabels" -}}
+app.cpln.io/name: {{ .Release.Name }}
+app.cpln.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/_helpers.tpl
+++ b/redis/versions/3.4.0/templates/_helpers.tpl
@@ -236,32 +236,8 @@ Validate auth configuration block
 {{/* Labeling */}}
 
 {{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "redis.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 Common labels
 */}}
 {{- define "redis.tags" -}}
-helm.sh/chart: {{ include "redis.chart" . }}
-{{ include "redis.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.cpln.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.cpln.io/managed-by: {{ .Release.Service }}
-cpln/marketplace: "true"
-cpln/marketplace-template: redis
-cpln/marketplace-template-version: {{ .Chart.Version }}
-cpln/marketplace-gvc: {{ .Values.global.cpln.gvc }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "redis.selectorLabels" -}}
-app.cpln.io/name: {{ .Release.Name }}
-app.cpln.io/instance: {{ .Release.Name }}
+{{- include "cpln-common.tags" . }}
 {{- end }}

--- a/redis/versions/3.4.0/templates/domain-redis.yaml
+++ b/redis/versions/3.4.0/templates/domain-redis.yaml
@@ -1,0 +1,20 @@
+{{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled }}
+kind: domain
+name: {{ .Values.redis.publicAccess.address }}
+description: {{ .Values.redis.publicAccess.address }}
+spec:
+  acceptAllHosts: false
+  dnsMode: cname
+  {{- if gt (.Values.redis.replicas | int) 0 }}
+  ports:
+    {{- range $i := until (int .Values.redis.replicas) }}
+    - number: {{ add 6380 $i }}
+      protocol: tcp
+      routes:
+        - port: {{ add 6380 $i }}
+          prefix: /
+          replica: {{ $i }}
+          workloadLink: //gvc/{{ $.Values.global.cpln.gvc }}/workload/{{ include "redis.name" $ }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/domain-sentinel.yaml
+++ b/redis/versions/3.4.0/templates/domain-sentinel.yaml
@@ -1,0 +1,20 @@
+{{- if and (hasKey .Values.sentinel "publicAccess") .Values.sentinel.publicAccess.enabled }}
+kind: domain
+name: {{ .Values.sentinel.publicAccess.address }}
+description: {{ .Values.sentinel.publicAccess.address }}
+spec:
+  acceptAllHosts: false
+  dnsMode: cname
+  {{- if gt (.Values.sentinel.replicas | int) 0 }}
+  ports:
+    {{- range $i := until (int .Values.sentinel.replicas) }}
+    - number: {{ add 26380 $i }}
+      protocol: tcp
+      routes:
+        - port: {{ add 26380 $i }}
+          prefix: /
+          replica: {{ $i }}
+          workloadLink: //gvc/{{ $.Values.global.cpln.gvc }}/workload/{{ include "redis.sentinel.name" $ }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/identity-redis.yaml
+++ b/redis/versions/3.4.0/templates/identity-redis.yaml
@@ -1,0 +1,23 @@
+{{- include "redis.validateBackupConfig" . -}}
+kind: identity
+name: {{ include "redis.identity.name" . }}
+description: Redis Identity
+gvc: {{ .Values.global.cpln.gvc }}
+{{- if and .Values.backup.enabled (eq .Values.backup.provider "aws") }}
+aws:
+  cloudAccountLink: //cloudaccount/{{ .Values.backup.aws.cloudAccountName }}
+  policyRefs:
+    - cpln-connector
+    - aws::ReadOnlyAccess
+    - {{ .Values.backup.aws.policyName | quote }}
+{{- end }}
+{{- if and .Values.backup.enabled (eq .Values.backup.provider "gcp") }}
+gcp:
+  bindings:
+    - resource: //storage.googleapis.com/projects/_/buckets/{{ .Values.backup.gcp.bucket }}
+      roles:
+        - roles/storage.objectAdmin
+  cloudAccountLink: //cloudaccount/{{ .Values.backup.gcp.cloudAccountName }}
+  scopes:
+    - https://www.googleapis.com/auth/cloud-platform
+{{- end }}

--- a/redis/versions/3.4.0/templates/identity-sentinel.yaml
+++ b/redis/versions/3.4.0/templates/identity-sentinel.yaml
@@ -1,0 +1,4 @@
+kind: identity
+name: {{ include "redis.sentinelIdentity.name" . }}
+description: Redis Sentinel Identity
+gvc: {{ .Values.global.cpln.gvc }}

--- a/redis/versions/3.4.0/templates/policy-backup.yaml
+++ b/redis/versions/3.4.0/templates/policy-backup.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.backup.enabled }}
+kind: policy
+name: {{ include "redis.backupPolicy.name" . }}
+bindings:
+  - permissions:
+      - reveal
+    principalLinks:
+      - //gvc/{{ .Values.global.cpln.gvc }}/identity/{{ include "redis.identity.name" . }}
+targetKind: secret
+targetLinks:
+  - //secret/{{ include "redis.secretBackup.name" . }}
+  {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
+  - //secret/{{ .Values.redis.auth.fromSecret.name }}
+  {{- else if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+  - //secret/{{ include "redis.secretPassword.name" . }}
+  {{- end }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/policy-redis.yaml
+++ b/redis/versions/3.4.0/templates/policy-redis.yaml
@@ -1,0 +1,20 @@
+kind: policy
+name: {{ include "redis.policy.name" . }}
+bindings:
+  - permissions:
+      - reveal
+    principalLinks:
+      - //gvc/{{ .Values.global.cpln.gvc }}/identity/{{ include "redis.identity.name" . }}
+targetKind: secret
+targetLinks:
+  - //secret/{{ include "redis.secretConfig.name" . }}
+  {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
+  - //secret/{{ .Values.redis.auth.fromSecret.name }}
+  {{- else if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+  - //secret/{{ include "redis.secretPassword.name" . }}
+  {{- end }}
+  {{- if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "fromSecret") .Values.sentinel.auth.fromSecret.enabled }}
+  - //secret/{{ .Values.sentinel.auth.fromSecret.name }}
+  {{- else if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "password") .Values.sentinel.auth.password.enabled }}
+  - //secret/{{ include "redis.sentinelSecretPassword.name" . }}
+  {{- end }}

--- a/redis/versions/3.4.0/templates/policy-sentinel.yaml
+++ b/redis/versions/3.4.0/templates/policy-sentinel.yaml
@@ -1,0 +1,20 @@
+kind: policy
+name: {{ include "redis.sentinelPolicy.name" . }}
+bindings:
+  - permissions:
+      - reveal
+    principalLinks:
+      - //gvc/{{ .Values.global.cpln.gvc }}/identity/{{ include "redis.sentinelIdentity.name" . }}
+targetKind: secret
+targetLinks:
+  - //secret/{{ include "redis.sentinelSecretConfig.name" . }}
+  {{- if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "fromSecret") .Values.sentinel.auth.fromSecret.enabled }}
+  - //secret/{{ .Values.sentinel.auth.fromSecret.name }}
+  {{- else if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "password") .Values.sentinel.auth.password.enabled }}
+  - //secret/{{ include "redis.sentinelSecretPassword.name" . }}
+  {{- end }}
+  {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
+  - //secret/{{ .Values.redis.auth.fromSecret.name }}
+  {{- else if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+  - //secret/{{ include "redis.secretPassword.name" . }}
+  {{- end }}

--- a/redis/versions/3.4.0/templates/secret-backup.yaml
+++ b/redis/versions/3.4.0/templates/secret-backup.yaml
@@ -1,0 +1,17 @@
+{{- include "redis.validateBackupConfig" . }}
+{{- if .Values.backup.enabled }}
+kind: secret
+name: {{ include "redis.secretBackup.name" . }}
+description: Redis backup configuration
+tags:
+  {{- include "redis.tags" . | nindent 4 }}
+type: dictionary
+data:
+{{- if eq .Values.backup.provider "aws" }}
+  backup-bucket: {{ .Values.backup.aws.bucket | quote }}
+  aws-region: {{ .Values.backup.aws.region | quote }}
+{{- end }}
+{{- if eq .Values.backup.provider "gcp" }}
+  backup-bucket: {{ .Values.backup.gcp.bucket | quote }}
+{{- end }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/secret-redis-config.yaml
+++ b/redis/versions/3.4.0/templates/secret-redis-config.yaml
@@ -1,0 +1,15 @@
+kind: secret
+name: {{ include "redis.secretConfig.name" . }}
+type: opaque
+data:
+  encoding: plain
+  payload: |-
+    bind 0.0.0.0
+    protected-mode no
+    save 900 1
+    save 300 10
+    save 60 10000
+    appendonly yes
+    repl-backlog-size {{ .Values.redis.replication.backlogSize }}
+    repl-timeout {{ .Values.redis.replication.timeout }}
+    client-output-buffer-limit slave {{ .Values.redis.replication.slaveOutputBufferLimit }}

--- a/redis/versions/3.4.0/templates/secret-redis-password.yaml
+++ b/redis/versions/3.4.0/templates/secret-redis-password.yaml
@@ -1,0 +1,7 @@
+{{ if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+kind: secret
+name: {{ include "redis.secretPassword.name" . }}
+type: dictionary
+data:
+  password: {{ .Values.redis.auth.password.value | quote }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/secret-sentinel-config.yaml
+++ b/redis/versions/3.4.0/templates/secret-sentinel-config.yaml
@@ -1,0 +1,16 @@
+kind: secret
+name: {{ include "redis.sentinelSecretConfig.name" . }}
+type: opaque
+data:
+  encoding: plain
+  payload: |-
+    {{- if and (hasKey .Values.sentinel "persistence") .Values.sentinel.persistence.enabled }}
+    dir /etc/sentinel/data
+    {{- else }}
+    dir /tmp
+    {{- end }}
+    sentinel announce-hostnames yes
+    sentinel resolve-hostnames yes
+    sentinel down-after-milliseconds mymaster 5000
+    sentinel failover-timeout mymaster 10000
+    sentinel parallel-syncs mymaster 1

--- a/redis/versions/3.4.0/templates/secret-sentinel-password.yaml
+++ b/redis/versions/3.4.0/templates/secret-sentinel-password.yaml
@@ -1,0 +1,7 @@
+{{ if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "password") .Values.sentinel.auth.password.enabled }}
+kind: secret
+name: {{ include "redis.sentinelSecretPassword.name" . }}
+type: dictionary
+data:
+  password: {{ .Values.sentinel.auth.password.value | quote}}
+{{- end }}

--- a/redis/versions/3.4.0/templates/volumeset-redis.yaml
+++ b/redis/versions/3.4.0/templates/volumeset-redis.yaml
@@ -1,0 +1,26 @@
+{{- if and (hasKey .Values.redis "persistence") .Values.redis.persistence.enabled }}
+kind: volumeset
+name: {{ include "redis.volume.name" . }}
+gvc: {{ .Values.global.cpln.gvc }}
+spec:
+  fileSystemType: {{ .Values.redis.persistence.volumes.data.fileSystemType }}
+  initialCapacity: {{ .Values.redis.persistence.volumes.data.initialCapacity }}
+  performanceClass: {{ .Values.redis.persistence.volumes.data.performanceClass }}
+  {{- if and .Values.redis.persistence.volumes.data.customEncryption .Values.redis.persistence.volumes.data.customEncryption.enabled }}
+  customEncryption:
+    regions:
+      {{ .Values.redis.persistence.volumes.data.customEncryption.region }}:
+        keyId: '{{ .Values.redis.persistence.volumes.data.customEncryption.keyId }}'
+  {{- end }}
+  {{- if .Values.redis.persistence.volumes.data.snapshots }}
+  snapshots:
+    retentionDuration: {{ .Values.redis.persistence.volumes.data.snapshots.retentionDuration }}
+    schedule: {{ .Values.redis.persistence.volumes.data.snapshots.schedule }}
+  {{- end }}
+  {{- if .Values.redis.persistence.volumes.data.autoscaling }}
+  autoscaling:
+    maxCapacity: {{ .Values.redis.persistence.volumes.data.autoscaling.maxCapacity }}
+    minFreePercentage: {{ .Values.redis.persistence.volumes.data.autoscaling.minFreePercentage }}
+    scalingFactor: {{ .Values.redis.persistence.volumes.data.autoscaling.scalingFactor }}
+  {{- end }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/volumeset-sentinel.yaml
+++ b/redis/versions/3.4.0/templates/volumeset-sentinel.yaml
@@ -1,0 +1,26 @@
+{{- if and (hasKey .Values.sentinel "persistence") .Values.sentinel.persistence.enabled }}
+kind: volumeset
+name: {{ include "redis.sentinelVolume.name" . }}
+gvc: {{ .Values.global.cpln.gvc }}
+spec:
+  fileSystemType: {{ .Values.sentinel.persistence.volumes.data.fileSystemType }}
+  initialCapacity: {{ .Values.sentinel.persistence.volumes.data.initialCapacity }}
+  performanceClass: {{ .Values.sentinel.persistence.volumes.data.performanceClass }}
+  {{- if and .Values.sentinel.persistence.volumes.data.customEncryption .Values.sentinel.persistence.volumes.data.customEncryption.enabled }}
+  customEncryption:
+    regions:
+      {{ .Values.sentinel.persistence.volumes.data.customEncryption.region }}:
+        keyId: '{{ .Values.sentinel.persistence.volumes.data.customEncryption.keyId }}'
+  {{- end }}
+  {{- if .Values.sentinel.persistence.volumes.data.snapshots }}
+  snapshots:
+    retentionDuration: {{ .Values.sentinel.persistence.volumes.data.snapshots.retentionDuration }}
+    schedule: {{ .Values.sentinel.persistence.volumes.data.snapshots.schedule }}
+  {{- end }}
+  {{- if .Values.sentinel.persistence.volumes.data.autoscaling }}
+  autoscaling:
+    maxCapacity: {{ .Values.sentinel.persistence.volumes.data.autoscaling.maxCapacity }}
+    minFreePercentage: {{ .Values.sentinel.persistence.volumes.data.autoscaling.minFreePercentage }}
+    scalingFactor: {{ .Values.sentinel.persistence.volumes.data.autoscaling.scalingFactor }}
+  {{- end }}
+{{- end }}

--- a/redis/versions/3.4.0/templates/workload-backup.yaml
+++ b/redis/versions/3.4.0/templates/workload-backup.yaml
@@ -1,0 +1,75 @@
+{{- include "redis.validateBackupConfig" . }}
+{{- if .Values.backup.enabled }}
+kind: workload
+name: {{ include "redis.backup.name" . }}
+description: Redis Backup
+tags:
+  {{- include "redis.tags" . | nindent 2 }}
+spec:
+  type: cron
+  containers:
+    - name: backup-redis
+      cpu: {{ .Values.backup.resources.cpu | quote }}
+      memory: {{ .Values.backup.resources.memory | quote }}
+      env:
+      {{- if eq .Values.backup.provider "aws" }}
+        - name: AWS_REGION
+          value: cpln://secret/{{ include "redis.secretBackup.name" . }}.aws-region
+        - name: BACKUP_PROVIDER
+          value: aws
+        - name: BACKUP_BUCKET
+          value: cpln://secret/{{ include "redis.secretBackup.name" . }}.backup-bucket
+        - name: BACKUP_PREFIX
+          value: {{ .Values.backup.aws.prefix | quote }}
+      {{- end }}
+      {{- if eq .Values.backup.provider "gcp" }}
+        - name: BACKUP_PROVIDER
+          value: gcp
+        - name: BACKUP_BUCKET
+          value: cpln://secret/{{ include "redis.secretBackup.name" . }}.backup-bucket
+        - name: BACKUP_PREFIX
+          value: {{ .Values.backup.gcp.prefix | quote }}
+      {{- end }}
+        - name: REDIS_HOST
+          value: {{ include "redis.name" . }}.{{ .Values.global.cpln.gvc }}.cpln.local
+      {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
+        - name: REDIS_PASSWORD
+          value: cpln://secret/{{ .Values.redis.auth.fromSecret.name }}.{{ .Values.redis.auth.fromSecret.passwordKey }}
+      {{- else if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+        - name: REDIS_PASSWORD
+          value: cpln://secret/{{ include "redis.secretPassword.name" . }}.password
+      {{- end }}
+      image: {{ .Values.backup.image }}
+      inheritEnv: false
+  defaultOptions:
+    autoscaling:
+      maxConcurrency: 0
+      maxScale: 1
+      metric: disabled
+      minScale: 1
+      scaleToZeroDelay: 300
+      target: 95
+    capacityAI: false
+    debug: false
+    suspend: false
+    timeoutSeconds: 5
+  firewallConfig:
+    external:
+      inboundAllowCIDR: []
+      inboundBlockedCIDR: []
+      outboundAllowCIDR:
+        - 0.0.0.0/0
+      outboundAllowHostname: []
+      outboundAllowPort: []
+      outboundBlockedCIDR: []
+    internal:
+      inboundAllowType: none
+      inboundAllowWorkload: []
+  identityLink: //identity/{{ include "redis.identity.name" . }}
+  job:
+    concurrencyPolicy: Forbid
+    historyLimit: 5
+    restartPolicy: Never
+    schedule: {{ .Values.backup.schedule }}
+  supportDynamicTags: false
+{{- end }}

--- a/redis/versions/3.4.0/templates/workload-redis.yaml
+++ b/redis/versions/3.4.0/templates/workload-redis.yaml
@@ -259,6 +259,43 @@ spec:
           recoveryPolicy: retain
           uri: cpln://volumeset/{{ include "redis.volume.name" . }}
         {{- end }}
+{{- if and (hasKey .Values.redis "exporter") .Values.redis.exporter.enabled }}
+    - name: redis-exporter
+      image: {{ .Values.redis.exporter.image }}
+      cpu: {{ .Values.redis.exporter.resources.cpu }}
+      memory: {{ .Values.redis.exporter.resources.memory }}
+      minCpu: {{ .Values.redis.exporter.resources.minCpu }}
+      minMemory: {{ .Values.redis.exporter.resources.minMemory }}
+      inheritEnv: false
+      command: /bin/sh
+      args:
+        - '-c'
+        - |-
+          {{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled }}
+          POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+          PORT=$((6380 + POD_ID))
+          {{- else }}
+          PORT=6379
+          {{- end }}
+          exec redis_exporter --redis.addr="redis://localhost:${PORT}"
+      env:
+        {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
+        - name: REDIS_PASSWORD
+          value: cpln://secret/{{ .Values.redis.auth.fromSecret.name }}.{{ .Values.redis.auth.fromSecret.passwordKey }}
+        {{- else if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+        - name: REDIS_PASSWORD
+          value: cpln://secret/{{ include "redis.secretPassword.name" . }}.password
+        {{- else }}
+        []
+        {{- end }}
+      metrics:
+        path: /metrics
+        port: 9121
+        dropMetrics: {{ .Values.redis.exporter.dropMetrics | toYaml | nindent 8 }}
+      ports:
+        - number: 9121
+          protocol: http
+{{- end }}
   defaultOptions:
     autoscaling:
       maxConcurrency: 0

--- a/redis/versions/3.4.0/templates/workload-redis.yaml
+++ b/redis/versions/3.4.0/templates/workload-redis.yaml
@@ -277,7 +277,7 @@ spec:
           {{- else }}
           PORT=6379
           {{- end }}
-          exec redis_exporter --redis.addr="redis://localhost:${PORT}"
+          exec /redis_exporter --redis.addr="redis://localhost:${PORT}"
       env:
         {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
         - name: REDIS_PASSWORD
@@ -291,7 +291,7 @@ spec:
       metrics:
         path: /metrics
         port: 9121
-        dropMetrics: {{ .Values.redis.exporter.dropMetrics | toYaml | nindent 8 }}
+        dropMetrics:{{- if .Values.redis.exporter.dropMetrics }} {{ .Values.redis.exporter.dropMetrics | toYaml | nindent 10 }}{{- else }} []{{- end }}
       ports:
         - number: 9121
           protocol: http

--- a/redis/versions/3.4.0/templates/workload-redis.yaml
+++ b/redis/versions/3.4.0/templates/workload-redis.yaml
@@ -1,0 +1,317 @@
+{{ include "validateAuth" (dict "auth" .Values.redis.auth) }}
+kind: workload
+name: {{ include "redis.name" . }}
+description: Redis
+tags:
+  {{- if .Values.redis.tags }}
+{{ toYaml .Values.redis.tags | indent 2 }}
+  {{- end }}
+  # Sentinel discovery and replica startup must resolve `<pod>.<workload>:6379` even
+  # while the pod is still resyncing or marked NotReady by the replication-aware
+  # readiness probe. This tag exposes not-yet-Ready pods on the headless service so
+  # peers can reach them for replication and Sentinel can monitor them.
+  cpln/publishNotReadyAddresses: "true"
+  {{- include "redis.tags" . | nindent 2 }}
+spec:
+  type: stateful
+  containers:
+    - name: redis
+      env:
+      {{- if .Values.redis.env }}
+{{ toYaml .Values.redis.env | indent 8 }}
+      {{- end }}
+      {{- if and (hasKey .Values.redis "replicaDirect") .Values.redis.replicaDirect }}
+        - name: REPLICA_DIRECT
+          value: "true"
+      {{- end }}
+      {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
+        - name: CUSTOM_REDIS_PASSWORD
+          value: cpln://secret/{{ .Values.redis.auth.fromSecret.name }}.{{ .Values.redis.auth.fromSecret.passwordKey }}
+      {{- else if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+        - name: CUSTOM_REDIS_PASSWORD
+          value: cpln://secret/{{ include "redis.secretPassword.name" . }}.password
+      {{- end }}
+      {{- if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "fromSecret") .Values.sentinel.auth.fromSecret.enabled }}
+        - name: CUSTOM_SENTINEL_PASSWORD
+          value: cpln://secret/{{ .Values.sentinel.auth.fromSecret.name }}.{{ .Values.sentinel.auth.fromSecret.passwordKey }}
+      {{- else if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "password") .Values.sentinel.auth.password.enabled }}
+        - name: CUSTOM_SENTINEL_PASSWORD
+          value: cpln://secret/{{ include "redis.sentinelSecretPassword.name" . }}.password
+      {{- end }}
+      {{- if not (or .Values.redis.env .Values.redis.replicaDirect (and (hasKey .Values.redis "auth") (or (and (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled) (and (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled))) (and (hasKey .Values.sentinel "auth") (or (and (hasKey .Values.sentinel.auth "fromSecret") .Values.sentinel.auth.fromSecret.enabled) (and (hasKey .Values.sentinel.auth "password") .Values.sentinel.auth.password.enabled)))) }}
+        []
+      {{- end }}
+      args:
+        - '-c'
+        - |-
+          mkdir /etc/redis
+
+          cp /config/redis.conf /etc/redis/redis.conf
+
+          if [ -n "$CUSTOM_REDIS_PASSWORD" ]; then
+            echo "\nrequirepass $CUSTOM_REDIS_PASSWORD" >> /etc/redis/redis.conf
+            echo "\nmasterauth $CUSTOM_REDIS_PASSWORD" >> /etc/redis/redis.conf
+          fi
+          {{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled }}
+          POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+          PORT=$((6380 + POD_ID))
+          echo "\nport $PORT" >> /etc/redis/redis.conf
+          echo "\nreplica-announce-ip {{ .Values.redis.publicAccess.address }}" >> /etc/redis/redis.conf
+          echo "\nreplica-announce-port $PORT" >> /etc/redis/redis.conf
+          SELF_HOST="{{ .Values.redis.publicAccess.address }}"
+          SELF_PORT=$PORT
+          {{ else }}
+          PORT=6379
+          echo "\nport 6379" >> /etc/redis/redis.conf
+          POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+          LOCATION=${CPLN_LOCATION##*/}
+          CPLN_WORKLOAD_NAME="${CPLN_WORKLOAD##*/}"
+          if [ -n "$REPLICA_DIRECT" ]; then
+            echo "\nreplica-announce-ip replica-${POD_ID}.${CPLN_WORKLOAD_NAME}.${LOCATION}.${CPLN_GVC}.cpln.local" >> /etc/redis/redis.conf
+            SELF_HOST="replica-${POD_ID}.${CPLN_WORKLOAD_NAME}.${LOCATION}.${CPLN_GVC}.cpln.local"
+          else
+            echo "\nreplica-announce-ip ${HOSTNAME}.{{ include "redis.name" . }}" >> /etc/redis/redis.conf
+            SELF_HOST="${HOSTNAME}.{{ include "redis.name" . }}"
+          fi
+          echo "\nreplica-announce-port 6379" >> /etc/redis/redis.conf
+          SELF_PORT=6379
+          {{ end }}
+
+          # Discovery: ask sentinel who the master is, retrying forever. A
+          # redis cluster without reachable sentinels isn't manageable
+          # regardless, so blocking startup until they respond is acceptable.
+          # On cold start, sentinels respond from their static config
+          # (mymaster -> pod-0); after any failover with sentinel persistence
+          # enabled, they respond from CONFIG REWRITE state (the real master).
+          # The pod whose announced identity matches sentinel's answer boots
+          # as master; everyone else replicaof's it.
+          SENTINEL_REPLICAS={{ .Values.sentinel.replicas }}
+          SIDX=0
+          MASTER_HOST=""
+          MASTER_PORT=""
+          until echo "$MASTER_PORT" | grep -qE '^[0-9]+$'; do
+            {{- if and (hasKey .Values.sentinel "publicAccess") .Values.sentinel.publicAccess.enabled }}
+            S_HOST="{{ include "redis.sentinel.name" . }}-${SIDX}.{{ include "redis.sentinel.name" . }}"
+            S_PORT=$((26380 + SIDX))
+            {{- else if and (hasKey .Values.sentinel "replicaDirect") .Values.sentinel.replicaDirect }}
+            S_HOST="replica-${SIDX}.{{ include "redis.sentinel.name" . }}.${LOCATION}.${CPLN_GVC}.cpln.local"
+            S_PORT=26379
+            {{- else }}
+            S_HOST="{{ include "redis.sentinel.name" . }}-${SIDX}.{{ include "redis.sentinel.name" . }}"
+            S_PORT=26379
+            {{- end }}
+            if [ -n "$CUSTOM_SENTINEL_PASSWORD" ]; then
+              INFO=$(redis-cli -h "$S_HOST" -p "$S_PORT" --no-auth-warning -a "$CUSTOM_SENTINEL_PASSWORD" SENTINEL get-master-addr-by-name mymaster 2>/dev/null)
+            else
+              INFO=$(redis-cli -h "$S_HOST" -p "$S_PORT" SENTINEL get-master-addr-by-name mymaster 2>/dev/null)
+            fi
+            MASTER_HOST=$(echo "$INFO" | head -1)
+            MASTER_PORT=$(echo "$INFO" | tail -1)
+            if ! echo "$MASTER_PORT" | grep -qE '^[0-9]+$'; then
+              echo "Sentinel at $S_HOST:$S_PORT not responding; trying next"
+              SIDX=$(( (SIDX + 1) % SENTINEL_REPLICAS ))
+              [ $SIDX -eq 0 ] && sleep 5
+            fi
+          done
+          echo "Sentinel says master=$MASTER_HOST:$MASTER_PORT (self=$SELF_HOST:$SELF_PORT)"
+
+          # exec replaces the shell with redis-server so SIGTERM from the
+          # platform routes directly to redis-server instead of being swallowed
+          # by /bin/sh. Without exec, shutdown waits the full grace period
+          # before SIGKILL since the shell doesn't forward signals to children.
+          if [ "$MASTER_HOST" = "$SELF_HOST" ] && [ "$MASTER_PORT" = "$SELF_PORT" ]; then
+            echo "Booting as master"
+            exec {{ .Values.redis.serverCommand }} /etc/redis/redis.conf {{ .Values.redis.extraArgs }} --dir {{ .Values.redis.dataDir }}
+          else
+            echo "Booting as replica of $MASTER_HOST:$MASTER_PORT"
+            # Self-heal sentinel's view of the slave set. Without this, a
+            # scale-up race or a sentinel restart (which can wipe known-replica
+            # entries on volume loss) can leave this replica invisible to
+            # sentinel and orphaned at the next failover. SENTINEL RESET only
+            # refreshes sentinel's bookkeeping — no failover is triggered.
+            (
+              while true; do
+                if [ -n "$CUSTOM_REDIS_PASSWORD" ]; then
+                  redis-cli -p $PORT --no-auth-warning -a "$CUSTOM_REDIS_PASSWORD" ping >/dev/null 2>&1 && break
+                else
+                  redis-cli -p $PORT ping >/dev/null 2>&1 && break
+                fi
+                sleep 2
+              done
+              sleep 3
+              IDX=0
+              while [ $IDX -lt $SENTINEL_REPLICAS ]; do
+                {{- if and (hasKey .Values.sentinel "publicAccess") .Values.sentinel.publicAccess.enabled }}
+                RS_HOST="{{ include "redis.sentinel.name" . }}-${IDX}.{{ include "redis.sentinel.name" . }}"
+                RS_PORT=$((26380 + IDX))
+                {{- else if and (hasKey .Values.sentinel "replicaDirect") .Values.sentinel.replicaDirect }}
+                RS_HOST="replica-${IDX}.{{ include "redis.sentinel.name" . }}.${LOCATION}.${CPLN_GVC}.cpln.local"
+                RS_PORT=26379
+                {{- else }}
+                RS_HOST="{{ include "redis.sentinel.name" . }}-${IDX}.{{ include "redis.sentinel.name" . }}"
+                RS_PORT=26379
+                {{- end }}
+                if [ -n "$CUSTOM_SENTINEL_PASSWORD" ]; then
+                  redis-cli -h $RS_HOST -p $RS_PORT --no-auth-warning -a "$CUSTOM_SENTINEL_PASSWORD" SENTINEL RESET mymaster >/dev/null 2>&1 || true
+                else
+                  redis-cli -h $RS_HOST -p $RS_PORT SENTINEL RESET mymaster >/dev/null 2>&1 || true
+                fi
+                IDX=$((IDX + 1))
+              done
+            ) &
+            exec {{ .Values.redis.serverCommand }} /etc/redis/redis.conf {{ .Values.redis.extraArgs }} --dir {{ .Values.redis.dataDir }} --replicaof "$MASTER_HOST" "$MASTER_PORT"
+          fi
+      command: /bin/sh
+      cpu: {{ .Values.redis.resources.cpu }}
+      memory: {{ .Values.redis.resources.memory }}
+      minCpu: {{ .Values.redis.resources.minCpu }}
+      minMemory: {{ .Values.redis.resources.minMemory }}
+      image: {{ .Values.redis.image }}
+      readinessProbe:
+        exec:
+          command:
+            - /bin/bash
+            - "-c"
+            - |-
+                {{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled }}
+                POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+                PORT=$((6380 + POD_ID))
+                {{- else }}
+                PORT=6379
+                {{- end }}
+                rcli() {
+                  if [ -n "$CUSTOM_REDIS_PASSWORD" ]; then
+                    redis-cli -p $PORT --no-auth-warning -a "$CUSTOM_REDIS_PASSWORD" "$@"
+                  else
+                    redis-cli -p $PORT "$@"
+                  fi
+                }
+                rcli ping >/dev/null && \
+                if [ "$(rcli role | head -1)" = "slave" ]; then
+                  [ "$(rcli info replication | awk -F: '/master_link_status/{print $2}' | tr -d '\r')" = "up" ] && \
+                  [ "$(rcli info replication | awk -F: '/master_sync_in_progress/{print $2}' | tr -d '\r')" = "0" ]
+                fi
+        failureThreshold: {{ .Values.redis.probes.readiness.failureThreshold }}
+        initialDelaySeconds: {{ .Values.redis.probes.readiness.initialDelaySeconds }}
+        periodSeconds: {{ .Values.redis.probes.readiness.periodSeconds }}
+        successThreshold: 1
+        timeoutSeconds: {{ .Values.redis.probes.readiness.timeoutSeconds }}
+      # Explicit liveness probe — keep it permissive (just "is the process up?")
+      # so the platform doesn't kill a pod mid-resync. cpln derives the startup
+      # probe from the readiness probe (copies all timing, sets failureThreshold=30),
+      # so the startup window = initialDelaySeconds + (30 × periodSeconds). The
+      # readiness probe intentionally fails during full resync (master_link_status:up
+      # AND master_sync_in_progress:0); without a separate liveness override the
+      # platform would kill a slave doing a full resync before it could finish.
+      livenessProbe:
+        {{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled }}
+        exec:
+          command:
+            - /bin/bash
+            - "-c"
+            - |-
+                POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+                PORT=$((6380 + POD_ID))
+                exec 3<>/dev/tcp/127.0.0.1/$PORT
+        {{- else }}
+        tcpSocket:
+          port: 6379
+        {{- end }}
+        failureThreshold: {{ .Values.redis.probes.liveness.failureThreshold }}
+        initialDelaySeconds: {{ .Values.redis.probes.liveness.initialDelaySeconds }}
+        periodSeconds: {{ .Values.redis.probes.liveness.periodSeconds }}
+        successThreshold: 1
+        timeoutSeconds: {{ .Values.redis.probes.liveness.timeoutSeconds }}
+      {{- if and (hasKey .Values.redis "persistence") .Values.redis.persistence.enabled }}
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - rm -f {{ .Values.redis.dataDir }}/temp-*.rdb {{ .Values.redis.dataDir }}/temp-rewriteaof-*.aof
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 45; rm -f {{ .Values.redis.dataDir }}/temp-*.rdb {{ .Values.redis.dataDir }}/temp-rewriteaof-*.aof
+      {{- end }}
+      inheritEnv: false
+      ports:
+{{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled (gt (.Values.redis.replicas | int) 0) }}
+    {{- $startPort := 6380 }}
+    {{- $replicas := $.Values.redis.replicas | int }}
+    {{- range $replicaIndex := until $replicas }}
+        - number: {{ add $startPort $replicaIndex }}
+          protocol: tcp
+    {{- end }}
+{{- else }}
+        - number: 6379
+          protocol: tcp
+{{- end }}
+      volumes:
+        - path: /config/redis.conf
+          recoveryPolicy: retain
+          uri: cpln://secret/{{ include "redis.secretConfig.name" . }}
+        {{- if and (hasKey .Values.redis "persistence") .Values.redis.persistence.enabled }}
+        - path: {{ .Values.redis.dataDir }}
+          recoveryPolicy: retain
+          uri: cpln://volumeset/{{ include "redis.volume.name" . }}
+        {{- end }}
+  defaultOptions:
+    autoscaling:
+      maxConcurrency: 0
+      metric: disabled
+      minScale: {{ .Values.redis.replicas }}
+      maxScale: {{ .Values.redis.replicas }}
+      scaleToZeroDelay: 300
+      target: 100
+    capacityAI: false
+    debug: false
+    suspend: false
+    timeoutSeconds: {{ .Values.redis.timeoutSeconds }}
+    {{- if .Values.redis.multiZone }}
+    multiZone:
+      enabled: true
+    {{- else }}
+    multiZone:
+      enabled: false
+    {{- end }}
+  # Parallel pod management. Default OrderedReady serializes replica boots,
+  # which forces sentinels and redis pods to wait for each peer to be Ready
+  # before the next starts and produces extended cold-start +sdown noise.
+  # Parallel boots all replicas at once; publishNotReadyAddresses keeps peer
+  # DNS resolvable during the simultaneous cold start so the cluster can form.
+  rolloutOptions:
+    scalingPolicy: Parallel
+{{- if .Values.redis.requestRetryPolicy }}
+  requestRetryPolicy:
+{{ toYaml .Values.redis.requestRetryPolicy | indent 4 }}
+{{- end }}
+{{- if .Values.redis.firewall }}
+  firewallConfig:
+    {{- if or (hasKey .Values.redis.firewall "external_inboundAllowCIDR") (hasKey .Values.redis.firewall "external_outboundAllowCIDR") }}
+    external:
+      inboundAllowCIDR: {{- if .Values.redis.firewall.external_inboundAllowCIDR }}{{ .Values.redis.firewall.external_inboundAllowCIDR | splitList "," | toYaml | nindent 8 }}{{- else }} []{{- end }}
+      outboundAllowCIDR: {{- if .Values.redis.firewall.external_outboundAllowCIDR }}{{ .Values.redis.firewall.external_outboundAllowCIDR | splitList "," | toYaml | nindent 8 }}{{- else }} []{{- end }}
+    {{- end }}
+    {{- if hasKey .Values.redis.firewall "internal_inboundAllowType" }}
+    internal:
+      inboundAllowType: {{ default "[]" .Values.redis.firewall.internal_inboundAllowType }}
+      {{- if .Values.redis.firewall.inboundAllowWorkload }}
+      inboundAllowWorkload: {{ .Values.redis.firewall.inboundAllowWorkload | toYaml | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+  identityLink: //gvc/{{ .Values.global.cpln.gvc }}/identity/{{ include "redis.identity.name" . }}
+{{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled }}
+  loadBalancer:
+    replicaDirect: true
+{{- else if and (hasKey .Values.redis "replicaDirect") .Values.redis.replicaDirect }}
+  loadBalancer:
+    replicaDirect: true
+{{- else }}
+  loadBalancer:
+    replicaDirect: false
+{{- end }}

--- a/redis/versions/3.4.0/templates/workload-sentinel.yaml
+++ b/redis/versions/3.4.0/templates/workload-sentinel.yaml
@@ -1,0 +1,223 @@
+{{ include "validateAuth" (dict "auth" .Values.sentinel.auth) }}
+kind: workload
+name: {{ include "redis.sentinel.name" . }}
+description: Redis Sentinel
+tags:
+  {{- if .Values.sentinel.tags }}
+{{ toYaml .Values.sentinel.tags | indent 2 }}
+  {{- end }}
+  # Currently a no-op: the sentinel readiness probe is a plain `redis-cli ping`, so
+  # pods become Ready as soon as the port answers and the headless service exposes
+  # them anyway. Set here as a hedge — if the probe is ever tightened (e.g. to
+  # require quorum visibility or a known master), peers must still resolve each
+  # other via `<pod>.<workload>` during cold start to form the quorum, otherwise
+  # they deadlock: NotReady because no peers, no peers because NotReady.
+  cpln/publishNotReadyAddresses: "true"
+  {{- include "redis.tags" . | nindent 2 }}
+spec:
+  type: stateful
+  containers:
+    - name: sentinel
+      args:
+        - '-c'
+        - |-
+          {{- if and (hasKey .Values.sentinel "persistence") .Values.sentinel.persistence.enabled }}
+          mkdir -p /etc/sentinel/data
+          {{- else }}
+          mkdir -p /etc/sentinel
+          {{- end }}
+
+          # bootstrap_sentinel_conf: write /etc/sentinel/sentinel.conf only if
+          # sentinel hasn't already taken ownership of the file. The marker we
+          # check is the `sentinel myid <hex>` directive — sentinel writes this
+          # via CONFIG REWRITE within milliseconds of its first successful
+          # startup, and the chart's static template never contains it. So:
+          #   - marker present  → previous boot got far enough that sentinel
+          #     owns the file. Preserve everything (current master after any
+          #     failover, known replicas, peer sentinels).
+          #   - marker absent   → file missing, empty, or written but sentinel
+          #     never reached its first CONFIG REWRITE. Re-run bootstrap;
+          #     idempotent against the static config so safe to re-run.
+          # When sentinel.persistence is disabled this still runs every boot
+          # (ephemeral filesystem, no marker survives) — same behavior as the
+          # pre-marker chart. The check only changes behavior when /etc/sentinel
+          # is backed by a persistent volume.
+          bootstrap_sentinel_conf() {
+            if [ -s /etc/sentinel/sentinel.conf ] && grep -q "^sentinel myid " /etc/sentinel/sentinel.conf; then
+              echo "sentinel.conf already bootstrapped; preserving sentinel-managed state"
+              return 0
+            fi
+            echo "Bootstrapping sentinel.conf from static config"
+            cp /config/sentinel.conf /etc/sentinel/sentinel.conf
+
+            if [ -n "$CUSTOM_REDIS_PASSWORD" ]; then
+              echo "\nsentinel auth-pass mymaster $CUSTOM_REDIS_PASSWORD" >> /etc/sentinel/sentinel.conf
+            fi
+
+            if [ -n "$CUSTOM_SENTINEL_PASSWORD" ]; then
+              echo "\nrequirepass $CUSTOM_SENTINEL_PASSWORD" >> /etc/sentinel/sentinel.conf
+            fi
+
+            {{- if and (hasKey .Values.sentinel "publicAccess") .Values.sentinel.publicAccess.enabled }}
+            POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+            PORT=$((26380 + POD_ID))
+            echo "\nport $PORT" >> /etc/sentinel/sentinel.conf
+            echo "\nsentinel announce-ip {{ .Values.sentinel.publicAccess.address }}" >> /etc/sentinel/sentinel.conf
+            echo "\nsentinel announce-port $PORT" >> /etc/sentinel/sentinel.conf
+            {{ else }}
+            echo "\nport 26379" >> /etc/sentinel/sentinel.conf
+            POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+            LOCATION=${CPLN_LOCATION##*/}
+            CPLN_WORKLOAD_NAME="${CPLN_WORKLOAD##*/}"
+            if [ -n "$REPLICA_DIRECT" ]; then
+              echo "\nsentinel announce-ip replica-${POD_ID}.${CPLN_WORKLOAD_NAME}.${LOCATION}.${CPLN_GVC}.cpln.local" >> /etc/sentinel/sentinel.conf
+            else
+              echo "\nsentinel announce-ip ${HOSTNAME}.{{ include "redis.sentinel.name" . }}" >> /etc/sentinel/sentinel.conf
+            fi
+            echo "\nsentinel announce-port 26379" >> /etc/sentinel/sentinel.conf
+            {{ end }}
+            {{- if and (hasKey .Values.redis "publicAccess") .Values.redis.publicAccess.enabled }}
+            echo "sentinel monitor mymaster {{ .Values.redis.publicAccess.address }} 6380 ${REDIS_SENTINEL_QUORUM}" >> /etc/sentinel/sentinel.conf
+            {{- else if and (hasKey .Values.redis "replicaDirect") .Values.redis.replicaDirect }}
+            echo "sentinel monitor mymaster replica-0.{{ include "redis.name" . }}.${LOCATION}.${CPLN_GVC}.cpln.local 6379 ${REDIS_SENTINEL_QUORUM}" >> /etc/sentinel/sentinel.conf
+            {{- else }}
+            echo "sentinel monitor mymaster {{ include "redis.name" . }}-0.{{ include "redis.name" . }} 6379 ${REDIS_SENTINEL_QUORUM}" >> /etc/sentinel/sentinel.conf
+            {{- end }}
+          }
+
+          bootstrap_sentinel_conf
+
+          # exec replaces the shell with redis-sentinel so SIGTERM from the
+          # platform routes directly to redis-sentinel for clean shutdown.
+          # Without exec, the shell swallows the signal and sentinel only dies
+          # when the platform sends SIGKILL after the grace period expires.
+          exec redis-sentinel /etc/sentinel/sentinel.conf
+      command: /bin/sh
+      cpu: {{ .Values.sentinel.resources.cpu }}
+      memory: {{ .Values.sentinel.resources.memory }}
+      minCpu: {{ .Values.sentinel.resources.minCpu }}
+      minMemory: {{ .Values.sentinel.resources.minMemory }}
+      env:
+        - name: REDIS_SENTINEL_QUORUM
+          value: '{{ if .Values.sentinel.quorumAutoCalculation }}{{ add (div (int .Values.sentinel.replicas) 2) 1 }}{{ else }}{{ .Values.sentinel.quorumOverride }}{{ end }}'
+        - name: REDIS_SENTINEL_DATA_DIR
+          value: /etc/sentinel/data
+      {{- if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "fromSecret") .Values.redis.auth.fromSecret.enabled }}
+        - name: CUSTOM_REDIS_PASSWORD
+          value: cpln://secret/{{ .Values.redis.auth.fromSecret.name }}.{{ .Values.redis.auth.fromSecret.passwordKey }}
+      {{- else if and (hasKey .Values.redis "auth") (hasKey .Values.redis.auth "password") .Values.redis.auth.password.enabled }}
+        - name: CUSTOM_REDIS_PASSWORD
+          value: cpln://secret/{{ include "redis.secretPassword.name" . }}.password
+      {{- end }}
+      {{- if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "fromSecret") .Values.sentinel.auth.fromSecret.enabled }}
+        - name: CUSTOM_SENTINEL_PASSWORD
+          value: cpln://secret/{{ .Values.sentinel.auth.fromSecret.name }}.{{ .Values.sentinel.auth.fromSecret.passwordKey }}
+      {{- else if and (hasKey .Values.sentinel "auth") (hasKey .Values.sentinel.auth "password") .Values.sentinel.auth.password.enabled }}
+        - name: CUSTOM_SENTINEL_PASSWORD
+          value: cpln://secret/{{ include "redis.sentinelSecretPassword.name" . }}.password
+      {{- end }}
+      {{- if and (hasKey .Values.sentinel "replicaDirect") .Values.sentinel.replicaDirect }}
+        - name: REPLICA_DIRECT
+          value: "true"
+      {{- end }}
+      {{- if .Values.sentinel.env }}
+{{ toYaml .Values.sentinel.env | indent 8 }}
+      {{- end }}
+      image: {{ .Values.sentinel.image }}
+      readinessProbe:
+        exec:
+          command:
+            - /bin/bash
+            - "-c"
+            - |-
+                {{- if and (hasKey .Values.sentinel "publicAccess") .Values.sentinel.publicAccess.enabled }}
+                POD_ID=$(echo "$POD_NAME" | rev | cut -d'-' -f 1 | rev)
+                PORT=$((26380 + POD_ID))
+                {{- else }}
+                PORT=26379
+                {{- end }}
+                if [ ! -z "$CUSTOM_SENTINEL_PASSWORD" ]; then
+                  redis-cli -p $PORT --no-auth-warning -a "$CUSTOM_SENTINEL_PASSWORD" ping;
+                else
+                  redis-cli -p $PORT ping;
+                fi
+        failureThreshold: 10
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 4
+      inheritEnv: false
+      ports:
+{{- if and (hasKey .Values.sentinel "publicAccess") .Values.sentinel.publicAccess.enabled (gt (.Values.sentinel.replicas | int) 0) }}
+    {{- $startPort := 26380 }}
+    {{- $replicas := $.Values.sentinel.replicas | int }}
+    {{- range $replicaIndex := until $replicas }}
+        - number: {{ add $startPort $replicaIndex }}
+          protocol: tcp
+    {{- end }}
+{{- else }}
+        - number: 26379
+          protocol: tcp
+{{- end }}
+      volumes:
+        - path: /config/sentinel.conf
+          recoveryPolicy: retain
+          uri: cpln://secret/{{ include "redis.sentinelSecretConfig.name" . }}
+        {{- if and (hasKey .Values.sentinel "persistence") .Values.sentinel.persistence.enabled }}
+        - path: /etc/sentinel
+          recoveryPolicy: retain
+          uri: cpln://volumeset/{{ include "redis.sentinelVolume.name" . }}
+        {{- end }}
+  defaultOptions:
+    autoscaling:
+      maxConcurrency: 0
+      minScale: {{ .Values.sentinel.replicas }}
+      maxScale: {{ .Values.sentinel.replicas }}
+      metric: disabled
+      scaleToZeroDelay: 300
+      target: 100
+    capacityAI: false
+    debug: false
+    suspend: false
+    timeoutSeconds: {{ .Values.sentinel.timeoutSeconds }}
+    {{- if .Values.sentinel.multiZone }}
+    multiZone:
+      enabled: true
+    {{- else }}
+    multiZone:
+      enabled: false
+    {{- end }}
+  # See workload-redis.yaml for rationale. Parallel boots all sentinels at
+  # once instead of waiting for each to be Ready in sequence.
+  rolloutOptions:
+    scalingPolicy: Parallel
+{{- if .Values.sentinel.requestRetryPolicy }}
+  requestRetryPolicy:
+{{ toYaml .Values.sentinel.requestRetryPolicy | indent 4 }}
+{{- end }}
+{{- if .Values.sentinel.firewall }}
+  firewallConfig:
+    {{- if or (hasKey .Values.sentinel.firewall "external_inboundAllowCIDR") (hasKey .Values.sentinel.firewall "external_outboundAllowCIDR") }}
+    external:
+      inboundAllowCIDR: {{- if .Values.sentinel.firewall.external_inboundAllowCIDR }}{{ .Values.sentinel.firewall.external_inboundAllowCIDR | splitList "," | toYaml | nindent 8 }}{{- else }} []{{- end }}
+      outboundAllowCIDR: {{- if .Values.sentinel.firewall.external_outboundAllowCIDR }}{{ .Values.sentinel.firewall.external_outboundAllowCIDR | splitList "," | toYaml | nindent 8 }}{{- else }} []{{- end }}
+    {{- end }}
+    {{- if hasKey .Values.sentinel.firewall "internal_inboundAllowType" }}
+    internal:
+      inboundAllowType: {{ default "[]" .Values.sentinel.firewall.internal_inboundAllowType }}
+      {{- if .Values.sentinel.firewall.inboundAllowWorkload }}
+      inboundAllowWorkload: {{ .Values.sentinel.firewall.inboundAllowWorkload | toYaml | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+  identityLink: //gvc/{{ .Values.global.cpln.gvc }}/identity/{{ include "redis.sentinelIdentity.name" . }}
+{{- if and (hasKey .Values.sentinel "publicAccess") .Values.sentinel.publicAccess.enabled }}
+  loadBalancer:
+    replicaDirect: true
+{{- else if and (hasKey .Values.sentinel "replicaDirect") .Values.sentinel.replicaDirect }}
+  loadBalancer:
+    replicaDirect: true
+{{- else }}
+  loadBalancer:
+    replicaDirect: false
+{{- end }}

--- a/redis/versions/3.4.0/values.yaml
+++ b/redis/versions/3.4.0/values.yaml
@@ -60,7 +60,7 @@ redis:
     readiness:
       failureThreshold: 10
       initialDelaySeconds: 10  # extend if AOF load takes longer than this
-      periodSeconds: 5          # also controls startup window: budget = initialDelay + 30×period
+      periodSeconds: 5         # also controls startup window: budget = initialDelay + 30×period
       timeoutSeconds: 4
     liveness:
       failureThreshold: 5

--- a/redis/versions/3.4.0/values.yaml
+++ b/redis/versions/3.4.0/values.yaml
@@ -67,6 +67,15 @@ redis:
       initialDelaySeconds: 30
       periodSeconds: 10
       timeoutSeconds: 5
+  exporter:
+    enabled: false
+    image: oliver006/redis_exporter:v1.67.0-alpine
+    resources:
+      cpu: 50m
+      memory: 64Mi
+      minCpu: 20m
+      minMemory: 32Mi
+    dropMetrics: []  # e.g., ["redis_command_.*", "redis_keyspace_.*"]
   dataDir: /data
   persistence:
     enabled: false

--- a/redis/versions/3.4.0/values.yaml
+++ b/redis/versions/3.4.0/values.yaml
@@ -68,7 +68,7 @@ redis:
       periodSeconds: 10
       timeoutSeconds: 5
   exporter:
-    enabled: false
+    enabled: false    # adds a redis_exporter sidecar that exposes metrics at :9121/metrics
     image: oliver006/redis_exporter:v1.67.0-alpine
     resources:
       cpu: 50m

--- a/redis/versions/3.4.0/values.yaml
+++ b/redis/versions/3.4.0/values.yaml
@@ -1,0 +1,177 @@
+redis:
+  image: redis:7.4
+  resources:
+    cpu: 200m
+    memory: 256Mi
+    minCpu: 80m
+    minMemory: 128Mi
+  replicas: 3
+  timeoutSeconds: 15
+  multiZone: false
+  replicaDirect: false # https://docs.controlplane.com/reference/workload/general#internal-endpoint-formatting
+  auth:
+    fromSecret:
+      enabled: false
+      name: example-redis-auth-password
+      passwordKey: password
+    password:
+      enabled: false
+      value: your-password
+  serverCommand: redis-server  # Can be overridden based on the version of redis image
+  # extraArgs: "--maxclients 20000 --maxmemory 200mb --maxmemory-policy allkeys-lru"
+  publicAccess:
+    enabled: false
+    address: redis-test.example-cpln.com
+  firewall:
+    internal_inboundAllowType: "same-gvc" # Options: same-org / same-gvc(Recommended) / workload-list
+    # external_inboundAllowCIDR: 0.0.0.0/0 # Provide a comma-separated list
+    # # You can specify additional workloads with either same-gvc or workload-list:
+    # inboundAllowWorkload:
+    #   - //gvc/main-redis/workload/main-redis-sentinel
+    #   - //gvc/client-gvc/workload/client
+    # external_outboundAllowCIDR: "0.0.0.0/0" # Provide a comma-separated list
+  env: []
+  tags: {}
+  # requestRetryPolicy:
+  #   attempts: 2
+  #   retryOn:
+  #     - connect-failure
+  #     - refused-stream
+  #     - unavailable
+  #     - cancelled
+  #     - resource-exhausted
+  #     - retriable-status-codes
+  requestRetryPolicy: {}
+  # Replication tuning. See secret-redis-config.yaml for how these are rendered.
+  # backlogSize: sized for (peak write throughput × tolerable disconnect window).
+  #   1mb (Redis default) escalates any brief disconnect to a full RDB resync. 1gb
+  #   covers ~5 minutes of disconnect at ~3MB/s of writes.
+  # timeout (seconds): bound on full-resync transfer + RDB load + heartbeat.
+  #   60s (Redis default) is too low for multi-GB datasets — master/slave drop the
+  #   link mid-sync. 300s covers ~30GB at typical 1Gbps + load throughput.
+  # slaveOutputBufferLimit: "<hard> <soft> <seconds>". Default
+  #   "256mb 64mb 60" can't sustain a full resync of a multi-GB dataset at high
+  #   write rate — master kills the replica mid-stream. Bump for production loads.
+  replication:
+    backlogSize: 1gb
+    timeout: 300
+    slaveOutputBufferLimit: "2gb 512mb 300"
+  probes:
+    readiness:
+      failureThreshold: 10
+      initialDelaySeconds: 10  # extend if AOF load takes longer than this
+      periodSeconds: 5          # also controls startup window: budget = initialDelay + 30×period
+      timeoutSeconds: 4
+    liveness:
+      failureThreshold: 5
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+  dataDir: /data
+  persistence:
+    enabled: false
+    volumes:
+      data:
+        initialCapacity: 10 # In GB
+        performanceClass: general-purpose-ssd # general-purpose-ssd / high-throughput-ssd (Min 1000GB)
+        fileSystemType: ext4 # ext4 / xfs
+        snapshots:
+          retentionDuration: 7d
+          schedule: 0 0 * * * # UTC
+        autoscaling:
+          maxCapacity: 100 # In GB
+          minFreePercentage: 20
+          scalingFactor: 1.2
+        # customEncryption:
+        #   enabled: true
+        #   region: aws-us-east-1 # Replace with the appropriate region
+        #   keyId: arn:aws:kms:us-east-1:1234567890:key/d411f35a-1d31-4515-9934-4f193e042d80 # Replace with your AWS KMS key ARN
+
+sentinel:
+  image: redis:7.4
+  resources:
+    cpu: 200m
+    memory: 256Mi
+    minCpu: 80m
+    minMemory: 128Mi
+  replicas: 3
+  timeoutSeconds: 10
+  multiZone: false
+  replicaDirect: false # https://docs.controlplane.com/reference/workload/general#internal-endpoint-formatting
+  quorumAutoCalculation: true  # Set to false if you want to override quorum. Quorum is (replicas/2)+1
+  quorumOverride: null  # Only used if quorumAutoCalculation is false
+  auth:
+    fromSecret:
+      enabled: false
+      name: example-redis-auth-password
+      passwordKey: password
+    password:
+      enabled: false
+      value: your-password
+  publicAccess:
+    enabled: false
+    address: redis-sentinel-test.example-cpln.com
+  firewall:
+    internal_inboundAllowType: "same-gvc" # Options: same-org / same-gvc(Recommended)
+    # external_inboundAllowCIDR: 0.0.0.0/0 # Provide a comma-separated list
+    # # You can specify additional workloads with either same-gvc or workload-list:
+    # inboundAllowWorkload:
+    #   - //gvc/main-redis/workload/main-redis-sentinel
+    #   - //gvc/client-gvc/workload/client
+    # external_outboundAllowCIDR: "0.0.0.0/0" # Provide a comma-separated list
+  env: []
+  tags: {}
+  # requestRetryPolicy:
+  #   attempts: 2
+  #   retryOn:
+  #     - connect-failure
+  #     - refused-stream
+  #     - unavailable
+  #     - cancelled
+  #     - resource-exhausted
+  #     - retriable-status-codes
+  requestRetryPolicy: {}
+  # Sentinel persistence preserves the post-failover master across restarts via
+  # CONFIG REWRITE. Replicas query sentinel at startup, so persisted state lets
+  # them rejoin the real master rather than redis-0. Recommended ON in prod.
+  persistence:
+    enabled: false
+    volumes:
+      data:
+        initialCapacity: 10 # In GB
+        performanceClass: general-purpose-ssd # general-purpose-ssd / high-throughput-ssd (Min 1000GB)
+        fileSystemType: ext4 # ext4 / xfs
+        snapshots:
+          retentionDuration: 7d
+          schedule: 0 0 * * * # UTC
+        autoscaling:
+          maxCapacity: 50 # In GB
+          minFreePercentage: 20
+          scalingFactor: 1.2
+        # customEncryption:
+        #   enabled: true
+        #   region: aws-us-east-1 # Replace with the appropriate region
+        #   keyId: arn:aws:kms:us-east-1:1234567890:key/d411f35a-1d31-4515-9934-4f193e042d80 # Replace with your AWS KMS key ARN
+
+backup:
+  enabled: false
+  image: controlplanecorporation/redis-backup:1.0
+  schedule: "0 2 * * *"   # daily at 2am UTC
+
+  resources:
+    cpu: 100m
+    memory: 128Mi
+
+  provider: aws # Options: aws or gcp
+
+  aws:
+    bucket: my-backup-bucket
+    region: us-east-1
+    cloudAccountName: my-backup-cloudaccount
+    policyName: my-backup-policy
+    prefix: redis/backups # folder name where your backups will be stored
+
+  gcp:
+    bucket: my-backup-bucket
+    cloudAccountName: my-backup-cloudaccount
+    prefix: redis/backups # folder name where your backups will be stored

--- a/redis/versions/3.4.0/values.yaml
+++ b/redis/versions/3.4.0/values.yaml
@@ -73,7 +73,7 @@ redis:
     resources:
       cpu: 50m
       memory: 64Mi
-      minCpu: 20m
+      minCpu: 25m
       minMemory: 32Mi
     dropMetrics: []  # e.g., ["redis_command_.*", "redis_keyspace_.*"]
   dataDir: /data


### PR DESCRIPTION
Expose readiness and liveness probe timing in values.yaml so users can extend the startup window for large persistent datasets. Add postStart/preStop lifecycle hooks when persistence is enabled to remove orphaned temp RDB and AOF rewrite files that accumulate on pod restarts mid-sync.